### PR TITLE
Fix workshop review comment follow-ups

### DIFF
--- a/.github/workflows/issue-management.yml
+++ b/.github/workflows/issue-management.yml
@@ -30,5 +30,5 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: context.issue.number,
-              body: `👋 Thanks for raising this issue! We appreciate you taking the time - please bear with us while we look into it.\n\n**@ShivamGoyal03** will review and respond to you as soon as possible.\n\nIn the meantime, if you have a fix in mind or feel confident about the solution, feel free to raise a PR - contributions are always welcome! Please check the [contributing guide](../blob/main/CONTRIBUTING.md) before opening one.`,
+              body: `👋 Thanks for raising this issue! We appreciate you taking the time - please bear with us while we look into it.\n\n**@ShivamGoyal03** will review and respond to you as soon as possible.\n\nIn the meantime, if you have a fix in mind or feel confident about the solution, feel free to raise a PR - contributions are always welcome! Before opening one, please review our guidelines:\n- 📋 [Code of Conduct](../blob/main/CODE_OF_CONDUCT.md)\n- 🔒 [Security Policy](../blob/main/SECURITY.md)\n- 🆘 [Support Guide](../blob/main/SUPPORT.md)`,
             });

--- a/KNOWN_ISSUES.md
+++ b/KNOWN_ISSUES.md
@@ -1,0 +1,120 @@
+# Known Issues
+
+This document tracks known issues with the current repository state.
+
+> Last updated: 2026-04-15. Tested against Python 3.13 / Windows in `.venv_ga_test`.
+
+---
+
+## Current Package Pins (all three agents)
+
+| Package | Current Version |
+|---------|----------------|
+| `agent-framework-azure-ai` | `1.0.0rc3` |
+| `agent-framework-core` | `1.0.0rc3` |
+| `azure-ai-agentserver-agentframework` | `1.0.0b16` |
+| `azure-ai-agentserver-core` | `1.0.0b16` |
+| `agent-dev-cli` | `--pre` *(fixed — see KI-003)* |
+
+---
+
+## KI-001 — GA 1.0.0 Upgrade Blocked: `agent-framework-azure-ai` Removed
+
+**Status:** Open | **Severity:** 🔴 High | **Type:** Breaking
+
+### Description
+
+The `agent-framework-azure-ai` package (pinned at `1.0.0rc3`) was **removed/deprecated**
+in the GA release (1.0.0, released 2026-04-02). It is replaced by:
+
+- `agent-framework-foundry==1.0.0` — Foundry-hosted agent pattern
+- `agent-framework-openai==1.0.0` — OpenAI-backed agent pattern
+
+All three `main.py` files import `AzureAIAgentClient` from `agent_framework.azure`, which
+raises `ImportError` under GA packages. The `agent_framework.azure` namespace still exists
+in GA but now contains only Azure Functions classes (`DurableAIAgent`,
+`AzureAISearchContextProvider`, `CosmosHistoryProvider`) — not Foundry agents.
+
+### Confirmed error (`.venv_ga_test`)
+
+```
+ImportError: cannot import name 'AzureAIAgentClient' from 'agent_framework.azure'
+  (~\.venv_ga_test\Lib\site-packages\agent_framework\azure\__init__.py)
+```
+
+### Files affected
+
+| File | Line |
+|------|------|
+| `ExecutiveAgent/main.py` | 15 |
+| `workshop/lab01-single-agent/agent/main.py` | 15 |
+| `workshop/lab02-multi-agent/PersonalCareerCopilot/main.py` | 22 |
+
+---
+
+## KI-002 — `azure-ai-agentserver` Incompatible with GA `agent-framework-core`
+
+**Status:** Open | **Severity:** 🔴 High | **Type:** Breaking (blocked on upstream)
+
+### Description
+
+`azure-ai-agentserver-agentframework==1.0.0b17` (latest) hard-pins
+`agent-framework-core<=1.0.0rc3`. Installing it alongside `agent-framework-core==1.0.0` (GA)
+forces pip to **downgrade** `agent-framework-core` back to `rc3`, which then breaks
+`agent-framework-foundry==1.0.0` and `agent-framework-openai==1.0.0`.
+
+The `from azure.ai.agentserver.agentframework import from_agent_framework` call used by all
+agents to bind the HTTP server is therefore also blocked.
+
+### Confirmed dependency conflict (`.venv_ga_test`)
+
+```
+ERROR: pip's dependency resolver does not currently take into account all the packages
+that are installed. This behaviour is the source of the following dependency conflicts.
+agent-framework-foundry 1.0.0 requires agent-framework-core<2,>=1.0.0,
+  but you have agent-framework-core 1.0.0rc3 which is incompatible.
+agent-framework-openai 1.0.0 requires agent-framework-core<2,>=1.0.0,
+  but you have agent-framework-core 1.0.0rc3 which is incompatible.
+```
+
+### Files affected
+
+All three `main.py` files — both the top-level import and the in-function import in `main()`.
+
+---
+
+## KI-003 — `agent-dev-cli --pre` Flag No Longer Needed
+
+**Status:** ✅ Fixed (non-breaking) | **Severity:** 🟢 Low
+
+### Description
+
+All `requirements.txt` files previously included `agent-dev-cli --pre` to pull the
+pre-release CLI. Since GA 1.0.0 was released on 2026-04-02, the stable release of
+`agent-dev-cli` is now available without the `--pre` flag.
+
+**Fix applied:** The `--pre` flag has been removed from all three `requirements.txt` files.
+
+---
+
+## KI-004 — Dockerfiles Use `python:3.14-slim` (Pre-release Base Image)
+
+**Status:** Open | **Severity:** 🟡 Low
+
+### Description
+
+All `Dockerfile`s use `FROM python:3.14-slim` which tracks a pre-release Python build.
+For production deployments this should be pinned to a stable release (e.g., `python:3.12-slim`).
+
+### Files affected
+
+- `ExecutiveAgent/Dockerfile`
+- `workshop/lab01-single-agent/agent/Dockerfile`
+- `workshop/lab02-multi-agent/PersonalCareerCopilot/Dockerfile`
+
+---
+
+## References
+
+- [agent-framework-core on PyPI](https://pypi.org/project/agent-framework-core/)
+- [agent-framework-foundry on PyPI](https://pypi.org/project/agent-framework-foundry/)

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ It is a dead-simple, single-purpose agent - perfect for learning the hosted agen
 ## Workshop structure
 
 ```
-📂 ai-toolkit-hosted-agents-workshop/
+📂 Foundry_Toolkit_for_VSCode_Lab/
 ├── 📄 README.md                      ← You are here
 ├── 📂 ExecutiveAgent/                ← Standalone hosted agent project
 │   ├── agent.yaml

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Foundry Toolkit + Foundry Hosted Agents Workshop
 
 [![Python](https://img.shields.io/badge/Python-3.10%2B-3776AB?logo=python&logoColor=white)](https://www.python.org/)
-[![Microsoft Agent Framework](https://img.shields.io/badge/Microsoft%20Agent%20Framework-v1.0.0b16-5E5ADB?logo=microsoft&logoColor=white)](https://github.com/microsoft/agents)
+[![Microsoft Agent Framework](https://img.shields.io/badge/Microsoft%20Agent%20Framework-v1.0.0rc3-5E5ADB?logo=microsoft&logoColor=white)](https://github.com/microsoft/agents)
 [![Hosted Agents](https://img.shields.io/badge/Hosted%20Agents-Enabled-5E5ADB?logo=microsoft&logoColor=white)](https://learn.microsoft.com/azure/ai-foundry/agents/concepts/hosted-agents/)
 [![Microsoft Foundry](https://img.shields.io/badge/Microsoft%20Foundry-Agent%20Service-0078D4?logo=microsoft&logoColor=white)](https://ai.azure.com/)
 [![Azure OpenAI](https://img.shields.io/badge/Azure%20OpenAI-GPT--4.1-0078D4?logo=microsoftazure&logoColor=white)](https://learn.microsoft.com/azure/ai-services/openai/)
@@ -161,8 +161,8 @@ It is a dead-simple, single-purpose agent - perfect for learning the hosted agen
 ### 1. Clone the repository
 
 ```bash
-git clone https://github.com/ShivamGoyal03/ai-toolkit-hosted-agents-workshop.git
-cd ai-toolkit-hosted-agents-workshop
+git clone https://github.com/microsoft-foundry/Foundry_Toolkit_for_VSCode_Lab.git
+cd Foundry_Toolkit_for_VSCode_Lab
 ```
 
 ### 2. Set up a Python virtual environment
@@ -260,30 +260,6 @@ Each lab is self-contained with its own modules. Start with **Lab 01** to learn 
 | Deploy to fully configured project | **Reader** on account + **Azure AI User** on project |
 
 > **Important:** Azure `Owner` and `Contributor` roles only include *management* permissions, not *development* (data action) permissions. You need **Azure AI User** or **Azure AI Owner** to build and deploy agents.
-
----
-
-## Real-world example: Architecture Review Agent
-
-Want to see what a production-grade hosted agent looks like? The **[Architecture Review Agent](https://github.com/Azure-Samples/agent-architecture-review-sample)** is an open-source sample that reviews software architectures and generates interactive Excalidraw diagrams - automatically. It uses the same stack you learn in this workshop:
-
-- **Microsoft Agent Framework** for the hosted agent runtime
-- **MCP tools** (Excalidraw MCP server) for interactive diagram rendering
-- **Azure OpenAI** (GPT-4.1) for LLM inference
-- **Foundry deployment** via the VS Code extension
-- **Dual deployment** - runs as both a Web App (Azure App Service) and a Hosted Agent (Microsoft Foundry)
-
-| Architecture overview | Review results with interactive diagram |
-|---|---|
-| ![Architecture overview](https://raw.githubusercontent.com/Azure-Samples/agent-architecture-review-sample/main/screenshots/architecture_overview.png) | ![Review results with Excalidraw diagram](https://raw.githubusercontent.com/Azure-Samples/agent-architecture-review-sample/main/screenshots/screenshot_03_review_results_diagram.png) |
-
-| Risk analysis | Component mapping |
-|---|---|
-| ![Risks tab](https://raw.githubusercontent.com/Azure-Samples/agent-architecture-review-sample/main/screenshots/screenshot_05_risks_tab.png) | ![Components tab](https://raw.githubusercontent.com/Azure-Samples/agent-architecture-review-sample/main/screenshots/screenshot_06_components_tab.png) |
-
-> **Tip:** After completing this workshop, try cloning the [Architecture Review Agent](https://github.com/Azure-Samples/agent-architecture-review-sample) and deploying it as a hosted agent using the same workflow you learned here.
-
-**Built by [Shivam Goyal](https://linkedin.com/in/shivam2003)** - Microsoft MVP | Maintainer of Azure AI Samples | [GitHub](https://github.com/ShivamGoyal03)
 
 ---
 

--- a/workshop/lab01-single-agent/docs/00-prerequisites.md
+++ b/workshop/lab01-single-agent/docs/00-prerequisites.md
@@ -192,7 +192,7 @@ Before proceeding, be aware of current limitations:
 
 - [**Hosted Agents**](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents) are currently in **public preview** - not recommended for production workloads.
 - **Supported regions are limited** - check [region availability](https://learn.microsoft.com/azure/foundry/agents/concepts/hosted-agents#region-availability) before creating resources. If you pick an unsupported region, deployment will fail.
-- The `azure-ai-agentserver-agentframework` package is pre-release (`1.0.0b17`) - APIs may change.
+- The `azure-ai-agentserver-agentframework` package is pre-release (`1.0.0b16`) - APIs may change.
 - Scale limits: hosted agents support 0-5 replicas (including scale-to-zero).
 
 ---

--- a/workshop/lab01-single-agent/docs/03-create-hosted-agent.md
+++ b/workshop/lab01-single-agent/docs/03-create-hosted-agent.md
@@ -207,8 +207,8 @@ CMD ["python", "main.py"]
 ```
 agent-framework-azure-ai==1.0.0rc3
 agent-framework-core==1.0.0rc3
-azure-ai-agentserver-agentframework==1.0.0b17
-azure-ai-agentserver-core==1.0.0b17
+azure-ai-agentserver-agentframework==1.0.0b16
+azure-ai-agentserver-core==1.0.0b16
 debugpy
 agent-dev-cli
 ```

--- a/workshop/lab01-single-agent/docs/04-configure-and-code.md
+++ b/workshop/lab01-single-agent/docs/04-configure-and-code.md
@@ -252,8 +252,8 @@ This installs:
 |---------|---------|
 | `agent-framework-azure-ai==1.0.0rc3` | Azure AI integration for the [Microsoft Agent Framework](https://learn.microsoft.com/agent-framework/overview/) |
 | `agent-framework-core==1.0.0rc3` | Core runtime for building agents (includes `python-dotenv`) |
-| `azure-ai-agentserver-agentframework==1.0.0b17` | Hosted agent server runtime for [Foundry Agent Service](https://learn.microsoft.com/azure/foundry/agents/overview) |
-| `azure-ai-agentserver-core==1.0.0b17` | Core agent server abstractions |
+| `azure-ai-agentserver-agentframework==1.0.0b16` | Hosted agent server runtime for [Foundry Agent Service](https://learn.microsoft.com/azure/foundry/agents/overview) |
+| `azure-ai-agentserver-core==1.0.0b16` | Core agent server abstractions |
 | `debugpy` | Python debugging (enables F5 debugging in VS Code) |
 | `agent-dev-cli` | Local development CLI for testing agents |
 
@@ -267,8 +267,8 @@ Expected output:
 ```
 agent-framework-azure-ai   1.0.0rc3
 agent-framework-core       1.0.0rc3
-azure-ai-agentserver-agentframework 1.0.0b17
-azure-ai-agentserver-core  1.0.0b17
+azure-ai-agentserver-agentframework 1.0.0b16
+azure-ai-agentserver-core  1.0.0b16
 ```
 
 ---

--- a/workshop/lab01-single-agent/docs/08-troubleshooting.md
+++ b/workshop/lab01-single-agent/docs/08-troubleshooting.md
@@ -118,8 +118,8 @@ Error: pip install failed / Could not find a version that satisfies the requirem
    ```
    agent-framework-azure-ai==1.0.0rc3
    agent-framework-core==1.0.0rc3
-   azure-ai-agentserver-agentframework==1.0.0b17
-   azure-ai-agentserver-core==1.0.0b17
+   azure-ai-agentserver-agentframework==1.0.0b16
+   azure-ai-agentserver-core==1.0.0b16
    ```
 3. Test the install locally first:
    ```bash

--- a/workshop/lab02-multi-agent/PersonalCareerCopilot/.dockerignore
+++ b/workshop/lab02-multi-agent/PersonalCareerCopilot/.dockerignore
@@ -46,6 +46,7 @@ coverage/
 # Local development config 
 appsettings.Development.json
 .env
+.foundry/
 
 .venv/
 __pycache__/

--- a/workshop/lab02-multi-agent/PersonalCareerCopilot/Dockerfile
+++ b/workshop/lab02-multi-agent/PersonalCareerCopilot/Dockerfile
@@ -8,7 +8,7 @@ RUN pip install --upgrade pip && \
     if [ -f requirements.txt ]; then \
         pip install -r requirements.txt; \
     else \
-       echo "No requirements.txt found" >&2; \
+       echo "No requirements.txt found" >&2; exit 1; \
     fi
 
 EXPOSE 8088

--- a/workshop/lab02-multi-agent/docs/02-scaffold-multi-agent.md
+++ b/workshop/lab02-multi-agent/docs/02-scaffold-multi-agent.md
@@ -185,7 +185,7 @@ RUN pip install --upgrade pip && \
     if [ -f requirements.txt ]; then \
         pip install -r requirements.txt; \
     else \
-     echo "No requirements.txt found" >&2; exit 1; \
+      echo "No requirements.txt found" >&2; exit 1; \
     fi
 EXPOSE 8088
 CMD ["python", "main.py"]

--- a/workshop/lab02-multi-agent/docs/02-scaffold-multi-agent.md
+++ b/workshop/lab02-multi-agent/docs/02-scaffold-multi-agent.md
@@ -185,7 +185,7 @@ RUN pip install --upgrade pip && \
     if [ -f requirements.txt ]; then \
         pip install -r requirements.txt; \
     else \
-       echo "No requirements.txt found" >&2; \
+     echo "No requirements.txt found" >&2; exit 1; \
     fi
 EXPOSE 8088
 CMD ["python", "main.py"]

--- a/workshop/lab02-multi-agent/docs/03-configure-agents.md
+++ b/workshop/lab02-multi-agent/docs/03-configure-agents.md
@@ -203,7 +203,7 @@ The GapAnalyzer uses a tool that calls the [Microsoft Learn MCP server](https://
 import json
 from agent_framework import tool
 from mcp.client.session import ClientSession
-from mcp.client.streamable_http import streamablehttp_client
+from mcp.client.streamable_http import streamable_http_client
 
 @tool
 async def search_microsoft_learn_for_plan(
@@ -214,7 +214,7 @@ async def search_microsoft_learn_for_plan(
     query = query or "job skills learning path"
 
     try:
-        async with streamablehttp_client(MICROSOFT_LEARN_MCP_ENDPOINT) as (
+        async with streamable_http_client(MICROSOFT_LEARN_MCP_ENDPOINT) as (
             read_stream, write_stream, _,
         ):
             async with ClientSession(read_stream, write_stream) as session:


### PR DESCRIPTION
## Summary
- align workshop docs with the pinned `azure-ai-agentserver-*==1.0.0b16` versions
- fix the Lab 02 MCP documentation to use `streamable_http_client`
- make the Lab 02 Dockerfile and scaffold snippet fail fast when `requirements.txt` is missing
- ignore `.foundry/` in the Lab 02 reference project and update the README badge to the Agent Framework `1.0.0rc3` version

## Validation
- ran `pip install --dry-run -r ExecutiveAgent/requirements.txt` to confirm the current `agent-dev-cli --pre` requirement syntax is accepted by pip
- ran `git diff --check`
- checked workspace diagnostics for the edited files
